### PR TITLE
feat: moreコマンドのWebSocketブロードキャスト実装

### DIFF
--- a/cmd/work-tracker/main.go
+++ b/cmd/work-tracker/main.go
@@ -74,7 +74,7 @@ func main() {
 	// 6. Create Use Cases (inject dependencies)
 	joinUsecase := command.NewJoinCommandUseCase(userRepository, sessionRepository, wsHub, expirationManager)
 	outUseCase := command.NewOutCommandUseCase(userRepository, sessionRepository, completeSessionService, expirationManager)
-	moreUseCase := command.NewMoreCommandUseCase(userRepository, sessionRepository, expirationManager)
+	moreUseCase := command.NewMoreCommandUseCase(userRepository, sessionRepository, wsHub, expirationManager)
 	changeUseCase := command.NewChangeCommandUseCase(userRepository, sessionRepository, wsHub)
 	getActiveSessionsUseCase := query.NewGetActiveSessionsUseCase(sessionRepository)
 	getUserInfoUseCase := query.NewGetUserInfoUseCase(userRepository, sessionRepository)

--- a/presentation/ws/hub.go
+++ b/presentation/ws/hub.go
@@ -121,6 +121,17 @@ func (h *Hub) BroadcastWorkNameChange(event command.WorkNameChangeBroadcast) {
 	h.Broadcast(wsEvent)
 }
 
+// BroadcastSessionExtend implements command.EventBroadcaster
+func (h *Hub) BroadcastSessionExtend(event command.SessionExtendBroadcast) {
+	wsEvent := SessionExtendEvent{
+		Type:          EventTypeSessionExtend,
+		ID:            event.SessionID,
+		UserID:        event.UserID,
+		NewPlannedEnd: event.NewPlannedEnd,
+	}
+	h.Broadcast(wsEvent)
+}
+
 // Client represents a WebSocket client
 type Client struct {
 	hub  *Hub

--- a/usecase/command/broadcaster.go
+++ b/usecase/command/broadcaster.go
@@ -27,11 +27,19 @@ type WorkNameChangeBroadcast struct {
 	WorkName  string
 }
 
+// SessionExtendBroadcast represents the data to broadcast when a session is extended
+type SessionExtendBroadcast struct {
+	SessionID     int64
+	UserID        int64
+	NewPlannedEnd time.Time
+}
+
 // EventBroadcaster is an interface for broadcasting events to clients
 type EventBroadcaster interface {
 	BroadcastSessionStart(event SessionStartBroadcast)
 	BroadcastSessionEnd(event SessionEndBroadcast)
 	BroadcastWorkNameChange(event WorkNameChangeBroadcast)
+	BroadcastSessionExtend(event SessionExtendBroadcast)
 }
 
 // NoOpBroadcaster is a no-op implementation of EventBroadcaster
@@ -41,6 +49,7 @@ type NoOpBroadcaster struct{}
 func (NoOpBroadcaster) BroadcastSessionStart(event SessionStartBroadcast)     {}
 func (NoOpBroadcaster) BroadcastSessionEnd(event SessionEndBroadcast)         {}
 func (NoOpBroadcaster) BroadcastWorkNameChange(event WorkNameChangeBroadcast) {}
+func (NoOpBroadcaster) BroadcastSessionExtend(event SessionExtendBroadcast)   {}
 
 // NoOpExpirationScheduler is a no-op implementation of ExpirationScheduler
 // Useful for testing

--- a/usecase/command/more_command_test.go
+++ b/usecase/command/more_command_test.go
@@ -65,7 +65,7 @@ func TestMoreCommand_Success(t *testing.T) {
 		},
 	}
 
-	uc := NewMoreCommandUseCase(userRepo, sessionRepo, expirationScheduler)
+	uc := NewMoreCommandUseCase(userRepo, sessionRepo, NoOpBroadcaster{}, expirationScheduler)
 
 	input := MoreCommandInput{
 		UserName: "yamada",
@@ -107,7 +107,7 @@ func TestMoreCommand_InvalidMinutes_TooSmall(t *testing.T) {
 	sessionRepo := &mockSessionRepository{}
 	expirationScheduler := &mockExpirationRescheduler{}
 
-	uc := NewMoreCommandUseCase(userRepo, sessionRepo, expirationScheduler)
+	uc := NewMoreCommandUseCase(userRepo, sessionRepo, NoOpBroadcaster{}, expirationScheduler)
 
 	input := MoreCommandInput{
 		UserName: "yamada",
@@ -133,7 +133,7 @@ func TestMoreCommand_InvalidMinutes_TooLarge(t *testing.T) {
 	sessionRepo := &mockSessionRepository{}
 	expirationScheduler := &mockExpirationRescheduler{}
 
-	uc := NewMoreCommandUseCase(userRepo, sessionRepo, expirationScheduler)
+	uc := NewMoreCommandUseCase(userRepo, sessionRepo, NoOpBroadcaster{}, expirationScheduler)
 
 	input := MoreCommandInput{
 		UserName: "yamada",
@@ -163,7 +163,7 @@ func TestMoreCommand_UserNotFound(t *testing.T) {
 	sessionRepo := &mockSessionRepository{}
 	expirationScheduler := &mockExpirationRescheduler{}
 
-	uc := NewMoreCommandUseCase(userRepo, sessionRepo, expirationScheduler)
+	uc := NewMoreCommandUseCase(userRepo, sessionRepo, NoOpBroadcaster{}, expirationScheduler)
 
 	input := MoreCommandInput{
 		UserName: "nonexistent",
@@ -210,7 +210,7 @@ func TestMoreCommand_NoActiveSession(t *testing.T) {
 
 	expirationScheduler := &mockExpirationRescheduler{}
 
-	uc := NewMoreCommandUseCase(userRepo, sessionRepo, expirationScheduler)
+	uc := NewMoreCommandUseCase(userRepo, sessionRepo, NoOpBroadcaster{}, expirationScheduler)
 
 	input := MoreCommandInput{
 		UserName: "yamada",


### PR DESCRIPTION
## 概要

moreコマンド実行時にセッション延長をリアルタイム通知するため、WebSocketブロードキャスト機能を実装しました。

Closes #10

## 実装内容

### 1. Usecaseレイヤー

**usecase/command/broadcaster.go**
- `SessionExtendBroadcast`構造体を追加
  - SessionID, UserID, NewPlannedEndフィールド
- `EventBroadcaster`インターフェースに`BroadcastSessionExtend`メソッドを追加
- `NoOpBroadcaster`に空実装を追加

**usecase/command/more_command.go**
- `MoreCommandUseCase`に`broadcaster`フィールドを追加
- コンストラクタで`EventBroadcaster`を受け取るように変更
- `Execute`メソッド内でデータベース更新後にブロードキャストを呼び出し

### 2. Presentationレイヤー

**presentation/ws/hub.go**
- `BroadcastSessionExtend`メソッドを実装
- `command.SessionExtendBroadcast`を`ws.SessionExtendEvent`に変換してブロードキャスト

### 3. 依存性注入

**cmd/work-tracker/main.go**
- `MoreCommandUseCase`初期化時に`wsHub`を渡すように変更

### 4. テスト

**usecase/command/more_command_test.go**
- 全テストケースで`NoOpBroadcaster{}`を渡すように更新

**presentation/http/handler/command_handler_integration_test.go**
- `TestCommandHandler_MoreCommand_E2E`を追加
  - ✅ ExtendSession_Success: セッション延長成功ケース
  - ✅ ExtendSession_UserNotFound: ユーザー未登録ケース
  - ✅ ExtendSession_NoActiveSession: アクティブセッションなしケース

## テスト結果

- ✅ 全ユニットテスト合格
- ✅ 全E2Eテスト合格  
- ✅ lintクリア

## 変更ファイル

- 6ファイル変更
- +207行/-10行

## ブロードキャストフロー

1. ユーザーが`!more 30`を実行
2. `MoreCommandUseCase.Execute`がセッションを延長
3. データベースを更新
4. `BroadcastSessionExtend`で全WebSocketクライアントに通知
5. ExpirationSchedulerを再スケジュール

## WebSocketイベント構造

```json
{
  "type": "session_extend",
  "session_id": 123,
  "user_id": 456,
  "new_planned_end": "2025-11-24T15:30:00Z"
}
```

## 次のステップ

このPRマージ後、フロントエンド側でこのイベントを受け取り、残り時間表示を更新する実装が必要です（Issue #6）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)